### PR TITLE
Add command line interface with true UDP radio functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,13 @@
     "compile": "tsc",
     "test": "ava",
     "clean": "gts clean",
+    "cli": "node ./build/src/cli/index.js",
     "lint": "eslint './src/**/*.ts' './test/**/*.ts'"
   },
   "dependencies": {
-    "ava": "^3.10.0"
+    "@types/yargs": "^15.0.5",
+    "ava": "^3.10.0",
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@ava/typescript": "^1.1.1",
@@ -29,6 +32,9 @@
     "gts": "^2.0.2",
     "prettier": "^2.0.5",
     "typescript": "^3.8.3"
+  },
+  "engines": {
+    "node": ">12.11.0"
   },
   "files": [
     "./build/src/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "lint": "eslint './src/**/*.ts' './test/**/*.ts'"
   },
   "dependencies": {
-    "@types/yargs": "^15.0.5",
     "ava": "^3.10.0",
     "yargs": "^15.4.1"
   },
@@ -22,6 +21,7 @@
     "@ava/typescript": "^1.1.1",
     "@google/local-home-sdk": "^1.1.0",
     "@types/node": "^13.11.1",
+    "@types/yargs": "^15.0.5",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "chalk": "^4.0.0",
     "eslint": "^7.5.0",

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1,0 +1,21 @@
+# Command Line Interface
+
+This is a simple command line interface for interacting with a Local Fulfillment app.
+
+# Usage
+
+TODO(cjdaly) update usage
+
+**To start a virtual device:**
+
+`npm start -- --udp_discovery_port 3320 --udp_discovery_packet ff --device_id local-device-id`
+
+**Example Commands:**
+
+`udp-scan --broadcast_address localhost --broadcast_port 3320 --listen_port 3311 --discovery_packet ff`
+
+`simulate-identify --request_id sample-request-id --discovery_buffer ff --device_id test-device-id-simulate`
+
+`trigger-execute --local_device_id local-device-id --command action.devices.commands.ColorAbsolute --params {"color":{"name":"magenta","spectrumRGB":"0xff00ff"}} --custom_data {"channel":1,"leds":8,"control_protocol":"UDP","port":7890}`
+
+`trigger-execute --local_device_id local-device-id --command action.devices.commands.ColorAbsolute --params {"color":{"name":"red","spectrumRGB":"0xebae34"}} --custom_data {"channel":1,"leds":2,"control_protocol":"TCP","port":7890}`

--- a/src/cli/command-processor.ts
+++ b/src/cli/command-processor.ts
@@ -187,7 +187,7 @@ export class CommandProcessor {
             const commandMessage = await this.parseIntent(input);
             if (commandMessage === undefined) {
               // Exit command recieved. Resolve promise.
-              console.log('Exit command recieved.  Terminating...');
+              console.log('Exit command received.  Terminating...');
               resolve();
               return;
             }

--- a/src/cli/command-processor.ts
+++ b/src/cli/command-processor.ts
@@ -1,0 +1,210 @@
+import {Worker} from 'worker_threads';
+import yargs from 'yargs/yargs';
+import * as readline from 'readline';
+import {CommandMessage, READY_FOR_MESSAGE, CHECK_READY} from './commands';
+import {ExecuteMessage, IdentifyMessage, ScanMessage} from './commands';
+import {UDPScanConfig} from '../radio/radio-controller';
+
+/**
+ * Class to parse raw user input from stdin.
+ */
+export class CommandProcessor {
+  private worker: Worker;
+  constructor(worker: Worker) {
+    this.worker = worker;
+  }
+
+  /**
+   * Parses a string and returns a CommandMessage, if valid.
+   * @param userCommand  A string to parse.
+   * @returns  A promise that resolves to a valid `CommandMessage`,
+   *   or void if an `exit` command was detected
+   */
+  private async parseIntent(
+    userCommand: string
+  ): Promise<CommandMessage | void> {
+    const argv = await yargs()
+      .command(
+        'udp-scan',
+        'Scan and identify devices with a given UDP scan configuration.',
+        yargs => {
+          return yargs
+            .option('broadcast_address', {
+              describe: 'Destination IP address foir the UDP broadcast.',
+              type: 'string',
+              demandOption: true,
+            })
+            .option('broadcast_port', {
+              describe: 'The destination port for the UDP discovery broadcast.',
+              type: 'number',
+              demandOption: true,
+            })
+            .option('listen_port', {
+              describe: 'The port to listen for the UDP discvery response.',
+              type: 'number',
+              demandOption: true,
+            })
+            .option('discovery_packet', {
+              describe: 'The payload to send in the UDP broadcast.',
+              type: 'string',
+              demandOption: true,
+            })
+            .option('request_id', {
+              describe: 'An optional request ID for the Identify Request.',
+              type: 'string',
+              default: 'default-request-id',
+              demandOption: false,
+            })
+            .option('device_id', {
+              describe: 'The device ID to include in the Identify Request.',
+              type: 'string',
+              default: 'default-device-id',
+              demandOption: false,
+            });
+        }
+      )
+      .command(
+        'simulate-identify',
+        'Manually trigger an Identify response.',
+        yargs => {
+          return yargs
+            .option('request_id', {
+              describe: 'The request Id',
+              type: 'string',
+              demandOption: true,
+            })
+            .option('discovery_buffer', {
+              describe: 'The IDENTIFY dicovery buffer represented as a string',
+              type: 'string',
+              demandOption: true,
+            })
+            .option('device_id', {
+              describe: 'The device Id',
+              type: 'string',
+              demandOption: true,
+            });
+        }
+      )
+      .command('trigger-execute', 'Trigger an Execute command.', yargs => {
+        return yargs
+          .option('local_device_id', {
+            describe: 'The local device Id',
+            type: 'string',
+            demandOption: true,
+          })
+          .option('command', {
+            describe: 'The execute command to send to device_id',
+            type: 'string',
+            demandOption: true,
+          })
+          .option('params', {
+            describe:
+              'The params argument for the execute command, in JSON format',
+            type: 'string',
+            default: '{}',
+            demandOption: false,
+          })
+          .option('custom_data', {
+            describe:
+              'The customData argument for the execute command, in JSON format',
+            type: 'string',
+            default: '{}',
+            demandOption: false,
+          });
+      })
+      .command('exit', 'Exit the command line interface.')
+      .demandCommand(1, 'Must provide a valid command')
+      .help()
+      .parse(userCommand, (error: Error) => {
+        if (error !== null) {
+          throw error;
+        }
+      });
+
+    /**
+     * Parse argv based on command and return a `CommandMessage`
+     */
+    const command = argv._[0];
+    switch (command) {
+      case 'udp-scan': {
+        const scanConfig = new UDPScanConfig(
+          argv.broadcast_address,
+          argv.broadcast_port,
+          argv.listen_port,
+          argv.discovery_packet
+        );
+        return new ScanMessage(argv.device_id, argv.request_id, scanConfig);
+      }
+      case 'simulate-identify':
+        return new IdentifyMessage(
+          argv.request_id,
+          argv.discovery_buffer,
+          argv.device_id
+        );
+      case 'trigger-execute':
+        return new ExecuteMessage(
+          argv.request_id,
+          argv.local_device_id,
+          argv.command,
+          JSON.parse(argv.params),
+          JSON.parse(argv.custom_data)
+        );
+      case 'exit':
+        return Promise.resolve();
+      default:
+        throw new Error('Unsupported command: ' + command);
+    }
+  }
+
+  /**
+   * The main user input to response loop.
+   * Recieves raw user input and attempts to parse and forward
+   * messages to the worker thread.
+   */
+  async processUserInput(): Promise<void> {
+    // Open a readline interface
+    const readlineInterface = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    await new Promise(resolve => {
+      // Pings the worker thread.
+      this.worker.postMessage(CHECK_READY);
+
+      this.worker.on('message', async message => {
+        // Waits for worker thread to indicate it's ready to take another message.
+        if (message !== READY_FOR_MESSAGE) {
+          return;
+        }
+        readlineInterface.question('Awaiting input...\n', async input => {
+          if (input.length === 0) {
+            // Ping worker thread.
+            this.worker.postMessage(CHECK_READY);
+            return;
+          }
+          try {
+            const commandMessage = await this.parseIntent(input);
+            if (commandMessage === undefined) {
+              // Exit command recieved. Resolve promise.
+              console.log('Exit command recieved.  Terminating...');
+              resolve();
+              return;
+            }
+            // Post `CommandMessage` to worker thread.
+            this.worker.postMessage(commandMessage);
+          } catch (error) {
+            // Catch possible parsing error.
+            console.error(error);
+            // Ping worker thread.
+            this.worker.postMessage(CHECK_READY);
+          }
+        });
+      });
+    });
+
+    // Clean up the readline interface.
+    readlineInterface.close();
+    return Promise.resolve();
+  }
+}

--- a/src/cli/command-processor.ts
+++ b/src/cli/command-processor.ts
@@ -30,7 +30,7 @@ export class CommandProcessor {
         yargs => {
           return yargs
             .option('broadcast_address', {
-              describe: 'Destination IP address foir the UDP broadcast.',
+              describe: 'Destination IP address for the UDP broadcast.',
               type: 'string',
               demandOption: true,
             })
@@ -74,7 +74,7 @@ export class CommandProcessor {
               demandOption: true,
             })
             .option('discovery_buffer', {
-              describe: 'The IDENTIFY dicovery buffer represented as a string',
+              describe: 'The IDENTIFY discovery buffer represented as a string',
               type: 'string',
               demandOption: true,
             })

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,95 @@
+import {UDPScanConfig} from '../radio/radio-controller';
+type CommandType = 'SCAN' | 'IDENTIFY' | 'EXECUTE';
+
+/**
+ * A flag for the worker thread to indicate it's ready to recieve messages.
+ */
+export const READY_FOR_MESSAGE = 'READY_FOR_MESSAGE';
+
+/**
+ * A flag for the main thread to check if worker is ready to process messages.
+ */
+export const CHECK_READY = 'CHECK_READY';
+
+/**
+ * An interface to differentiate messages on the worker thread.
+ */
+export interface CommandMessage {
+  commandType: CommandType;
+}
+
+/**
+ * A class containing all parameters needed to process an Identify command.
+ */
+export class IdentifyMessage implements CommandMessage {
+  commandType: CommandType = 'IDENTIFY';
+  requestId: string;
+  discoveryBuffer: string;
+  deviceId: string;
+  /**
+   * @param requestId  The request id for a triggered Identify request.
+   * @param discoveryBuffer  The discovery buffer to send in a triggered Identify request.
+   * @param deviceId workerMessageType The device id for a triggered Identify request.
+   * @returns  A new IntentMessage instance.
+   */
+  constructor(requestId: string, discoveryBuffer: string, deviceId: string) {
+    this.requestId = requestId;
+    this.discoveryBuffer = discoveryBuffer;
+    this.deviceId = deviceId;
+  }
+}
+
+/**
+ * A class containing all parameters needed to process an Identify command.
+ */
+export class ExecuteMessage implements CommandMessage {
+  commandType: CommandType = 'EXECUTE';
+  requestId: string;
+  localDeviceId: string;
+  executeCommand: string;
+  params: Record<string, unknown>;
+  customData: Record<string, unknown>;
+
+  /**
+   * @param requestId  The request id for a triggered Execute request.
+   * @param localDeviceId  The localDeviceId for a triggered Execute request.
+   * @param executeCommand  The single command string to set in the triggered Execute request.
+   * @param params  The params array for the single Execute command.
+   * @param customData  The customData array for the single Execute command.
+   * @param listenPort  The port to listen on for an Execute command response.
+   * @returns  A new ExecuteCommand instance.
+   */
+  constructor(
+    requestId: string,
+    localDeviceId: string,
+    executeCommand: string,
+    params: Record<string, unknown>,
+    customData: Record<string, unknown>
+  ) {
+    this.requestId = requestId;
+    this.localDeviceId = localDeviceId;
+    this.executeCommand = executeCommand;
+    this.params = params;
+    this.customData = customData;
+  }
+}
+
+/**
+ * A class containing all parametes needed to process a Scan command.
+ */
+export class ScanMessage implements CommandMessage {
+  commandType: CommandType = 'SCAN';
+  deviceId: string;
+  requestId: string;
+  scanConfig: UDPScanConfig;
+  /**
+   * @param deviceId  The deviceId to assign when a device matches.
+   * @param requestId  The requestId to assign to the `IdentifyRequest`.
+   * @param scanConfig  The UDP scan configuration.
+   */
+  constructor(deviceId: string, requestId: string, scanConfig: UDPScanConfig) {
+    this.deviceId = deviceId;
+    this.requestId = requestId;
+    this.scanConfig = scanConfig;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,36 @@
+import yargs from 'yargs/yargs';
+import {Worker} from 'worker_threads';
+import {CommandProcessor} from './command-processor';
+
+const APP_INSTANCE_PATH = './build/src/cli/worker-instance.js';
+
+/**
+ * Process initial command-line arguments.
+ */
+const argv = yargs()
+  .usage('Usage: $0 --app PATH')
+  .options('app', {
+    describe: 'The path of the Local Fulfillment App entry point.',
+    type: 'string',
+    demandOption: true,
+  })
+  .parse(process.argv.slice(2));
+
+/**
+ * Entry point for running the command line interface.
+ */
+async function main() {
+  const worker = new Worker(APP_INSTANCE_PATH, {
+    workerData: argv.app,
+  }).on('error', error => {
+    console.error(
+      'An error occured while trying to initialize the command line interface:\n' +
+        error.toString()
+    );
+  });
+  const commandProcessor = new CommandProcessor(worker);
+  await commandProcessor.processUserInput();
+  worker.terminate();
+}
+
+main();

--- a/src/cli/platform-worker.ts
+++ b/src/cli/platform-worker.ts
@@ -53,19 +53,19 @@ export class PlatformWorker {
         try {
           const scanMessage = workerMessage as ScanMessage;
           // Perform a UDP scan with given config.
-          const scanResults = await this.radioController.udpScan(
+          const scanRemoteInfo = await this.radioController.udpScan(
             scanMessage.scanConfig
           );
           // Trigger the identifyHandler with scan results.
           await this.mockLocalHomePlatform.triggerIdentify(
             scanMessage.requestId,
-            scanResults.buffer,
+            scanRemoteInfo.buffer,
             scanMessage.deviceId
           );
           // Save association between deviceId and local IP address.
           this.radioDeviceManager.addDeviceIdToAddress(
             scanMessage.deviceId,
-            scanResults.address
+            scanRemoteInfo.rinfo.address
           );
         } catch (error) {
           console.error('UDP scan failed:\n' + error);

--- a/src/cli/platform-worker.ts
+++ b/src/cli/platform-worker.ts
@@ -1,0 +1,126 @@
+import {createSimpleExecuteCommands} from '../platform/execute';
+import {MockLocalHomePlatform} from '../platform/mock-local-home-platform';
+import {AppStub} from '../platform/smart-home-app';
+import {extractStubs} from '../platform/stub-setup';
+import {RadioController} from '../radio/radio-controller';
+import {
+  ScanMessage,
+  CommandMessage,
+  ExecuteMessage,
+  IdentifyMessage,
+} from './commands';
+import {RadioDeviceManager} from '../radio/radio-device-manager';
+
+/**
+ * Class to recieve `CommandMessage`s and forward them to
+ * the respective platform components.
+ */
+export class PlatformWorker {
+  private appStub: AppStub;
+  private mockLocalHomePlatform: MockLocalHomePlatform;
+  private radioDeviceManager: RadioDeviceManager;
+  private radioController: RadioController;
+
+  /**
+   * Creates a new PlatformWorker.
+   * Initializes required platform components.
+   * @param appStub  The `App` instance to control.
+   * @returns  A new PlatformWorker instance.
+   */
+  constructor(appStub: AppStub) {
+    this.appStub = appStub;
+    this.mockLocalHomePlatform = extractStubs(
+      this.appStub
+    ).mockLocalHomePlatform;
+    // Save access to radio controls.
+    this.radioController = new RadioController();
+    // Create and save a typed `RadioDeviceManager`.
+    this.radioDeviceManager = new RadioDeviceManager(this.radioController);
+    // Inject radio functionality in the platform.
+    this.mockLocalHomePlatform.setDeviceManager(this.radioDeviceManager);
+  }
+
+  /**
+   * Takes a formed `CommandMessage` and takes corresponding action on the platform.
+   * @param workerMessage  A `CommandMessage` to process.
+   */
+  public async handleMessage(workerMessage: CommandMessage): Promise<void> {
+    switch (workerMessage.commandType) {
+      /**
+       * Handle a UDP Scan command.
+       */
+      case 'SCAN':
+        try {
+          const scanMessage = workerMessage as ScanMessage;
+          // Perform a UDP scan with given config.
+          const scanResults = await this.radioController.udpScan(
+            scanMessage.scanConfig
+          );
+          // Trigger the identifyHandler with scan results.
+          await this.mockLocalHomePlatform.triggerIdentify(
+            scanMessage.requestId,
+            scanResults.buffer,
+            scanMessage.deviceId
+          );
+          // Save association between deviceId and local IP address.
+          this.radioDeviceManager.addDeviceIdToAddress(
+            scanMessage.deviceId,
+            scanResults.address
+          );
+        } catch (error) {
+          console.error('UDP scan failed:\n' + error);
+        }
+        break;
+      /**
+       * Handle manual Identify trigger command.
+       */
+      case 'IDENTIFY':
+        try {
+          const identifyMessage = workerMessage as IdentifyMessage;
+          // Forward parameters to `triggerIdentify`.
+          await this.mockLocalHomePlatform.triggerIdentify(
+            identifyMessage.requestId,
+            Buffer.from(identifyMessage.discoveryBuffer, 'hex'),
+            identifyMessage.deviceId
+          );
+        } catch (error) {
+          console.error(
+            'An Error occured while triggering the identifyHandler: ' + error
+          );
+        }
+        break;
+      /**
+       * Handle an Execute command.
+       */
+      case 'EXECUTE':
+        try {
+          const executeMessage = workerMessage as ExecuteMessage;
+          const executeCommands = createSimpleExecuteCommands(
+            executeMessage.localDeviceId,
+            executeMessage.executeCommand!,
+            executeMessage.params,
+            executeMessage.customData
+          );
+
+          // Trigger an Execute intent.
+          const executeResponse = await this.mockLocalHomePlatform.triggerExecute(
+            executeMessage.requestId,
+            [executeCommands]
+          );
+
+          // Report the ExecuteResponse if succesful.
+          console.log(
+            'Execute handler triggered. ExecuteResponse was:\n' +
+              JSON.stringify(executeResponse)
+          );
+        } catch (error) {
+          console.error(
+            'An error occured when triggering the Execute handler:\n' +
+              error.toString()
+          );
+        }
+        break;
+    }
+    return Promise.resolve();
+  }
+}

--- a/src/cli/worker-instance.ts
+++ b/src/cli/worker-instance.ts
@@ -1,0 +1,65 @@
+/**
+ * Worker thread that runs an instance of a mocked local fulfillment app.
+ */
+import {parentPort, workerData} from 'worker_threads';
+import {smarthomeStub} from '../platform/stub-setup';
+import {AppStub} from '../platform/smart-home-app';
+import * as fs from 'fs';
+import {PlatformWorker} from './platform-worker';
+import {READY_FOR_MESSAGE, CHECK_READY} from './commands';
+
+/**
+ * Check that this worker thread was started properly
+ */
+if (parentPort === null) {
+  throw new Error("Couldn't start worker thread: parentPort was null");
+}
+
+/**
+ * Override the constructor to capture the AppStub instance.
+ */
+let appStubInstance: AppStub | undefined = undefined;
+class CliAppStub extends AppStub {
+  constructor(version: string) {
+    super(version);
+    appStubInstance = this;
+  }
+}
+
+/**
+ * Inject the stubs into the worker thread context.
+ */
+smarthomeStub.App = CliAppStub;
+(global as any).smarthome = smarthomeStub;
+
+/**
+ * Strips the file extension off the filepath and validates it.
+ */
+const modulePath = workerData.substring(0, workerData.lastIndexOf('.'));
+if (!fs.existsSync(workerData)) {
+  throw new Error('File at path ' + workerData + ' not found.');
+}
+
+// Runs the javascript specified in the app_path command line argument.
+require(modulePath);
+
+/**
+ * Checks that smarthome.App constructor was called.
+ */
+if (appStubInstance === undefined) {
+  throw new Error(
+    'There was no smarthome.App creation detected in the specified module.'
+  );
+}
+
+const platformWorker = new PlatformWorker(appStubInstance);
+
+/**
+ * Recieve a validated command and forward it to the platform instance.
+ */
+parentPort.on('message', async message => {
+  if (message !== CHECK_READY) {
+    await platformWorker.handleMessage(message);
+  }
+  parentPort!.postMessage(READY_FOR_MESSAGE);
+});

--- a/src/cli/worker-instance.ts
+++ b/src/cli/worker-instance.ts
@@ -37,7 +37,7 @@ smarthomeStub.App = CliAppStub;
  */
 const modulePath = workerData.substring(0, workerData.lastIndexOf('.'));
 if (!fs.existsSync(workerData)) {
-  throw new Error('File at path ' + workerData + ' not found.');
+  throw new Error(`File at path ${workerData} not found.`);
 }
 
 // Runs the javascript specified in the app_path command line argument.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@ import {smarthomeStub} from './platform/stub-setup';
 export * from './platform/mock-local-home-platform';
 export * from './platform/stub-setup';
 export * from './platform/smart-home-app';
-export * from './platform/device-manager';
+export * from './platform/mock-device-manager';
 export * from './platform/execute';
+export * from './radio/dataflow';
 /**
  * Injects the stubs into the global context on import.
  */

--- a/src/platform/execute.ts
+++ b/src/platform/execute.ts
@@ -62,32 +62,3 @@ export function createSimpleExecuteCommands(
     execution: [{command, params}],
   };
 }
-
-/**
- * Implementation of smarthome.DataFlow.UpdResponseData
- * for testing DeviceManager.
- */
-export class UdpResponseData implements smarthome.DataFlow.UdpResponseData {
-  constructor(
-    requestId: string,
-    deviceId: string,
-    udpResponse: smarthome.DataFlow.UdpResponse
-  ) {
-    this.requestId = requestId;
-    this.deviceId = deviceId;
-    this.udpResponse = udpResponse;
-  }
-  udpResponse: smarthome.DataFlow.UdpResponse;
-  requestId: string;
-  deviceId: string;
-  protocol: smarthome.Constants.Protocol = smarthome.Constants.Protocol.UDP;
-}
-
-export class UdpResponse implements smarthome.DataFlow.UdpResponse {
-  constructor(responsePackets?: string[]) {
-    if (responsePackets !== undefined) {
-      this.responsePackets = responsePackets;
-    }
-  }
-  responsePackets?: string[];
-}

--- a/src/platform/mock-device-manager.ts
+++ b/src/platform/mock-device-manager.ts
@@ -6,7 +6,7 @@ export const ERROR_UNEXPECTED_COMMAND_REQUEST =
   'Unable to process unexpected CommandRequest';
 export const ERROR_PENDING_REQUEST_MISMATCH =
   'The pending request did not match the expected value';
-export class DeviceManagerStub implements smarthome.DeviceManager {
+export class MockDeviceManager implements smarthome.DeviceManager {
   /** Action to call when an `IntentRequest` is marked with `markPending()`.*/
   private markPendingAction:
     | ((request: smarthome.IntentRequest) => void)

--- a/src/platform/stub-setup.ts
+++ b/src/platform/stub-setup.ts
@@ -3,8 +3,9 @@
  */
 import {AppStub} from './smart-home-app';
 import {MockLocalHomePlatform} from './mock-local-home-platform';
-import {DeviceManagerStub} from './device-manager';
+import {MockDeviceManager} from './mock-device-manager';
 import {ExecuteStub} from './execute';
+import {DataFlowStub} from '../radio/dataflow';
 
 export const smarthomeStub: {
   App: typeof smarthome.App;
@@ -40,15 +41,7 @@ export const smarthomeStub: {
       debugString?: string;
     },
   },
-  DataFlow: {
-    UdpRequestData: class {
-      data = '';
-      requestId = '';
-      deviceId = '';
-      protocol: smarthome.Constants.Protocol = smarthome.Constants.Protocol.UDP;
-      port = 0;
-    },
-  },
+  DataFlow: DataFlowStub,
   Constants: {
     Protocol: {
       BLE: 'BLE',
@@ -62,7 +55,7 @@ export const smarthomeStub: {
 
 export interface ExtractedStubs {
   mockLocalHomePlatform: MockLocalHomePlatform;
-  deviceManagerStub: DeviceManagerStub;
+  deviceManagerStub: MockDeviceManager;
 }
 
 /**
@@ -75,7 +68,9 @@ export function extractStubs(app: smarthome.App): ExtractedStubs {
   if (app instanceof AppStub) {
     return {
       mockLocalHomePlatform: app.getLocalHomePlatform(),
-      deviceManagerStub: app.getLocalHomePlatform().getDeviceManager(),
+      deviceManagerStub: app
+        .getLocalHomePlatform()
+        .getDeviceManager() as MockDeviceManager,
     };
   }
   throw new Error("Couldn't downcast App to AppStub");

--- a/src/radio/dataflow.ts
+++ b/src/radio/dataflow.ts
@@ -1,0 +1,53 @@
+/**
+ * Stubs to allow handlers to access smarthome.DataFlow
+ */
+export const DataFlowStub = {
+  UdpRequestData: class {
+    protocol: smarthome.Constants.Protocol = smarthome.Constants.Protocol.UDP;
+    requestId = '';
+    deviceId = '';
+    data = '';
+    port = 0;
+  },
+};
+
+/**
+ * An implementation of `smarthome.DataFlow.UdpResponseData` for
+ * responding to UDP requests.
+ */
+export class UdpResponseData implements smarthome.DataFlow.UdpResponseData {
+  udpResponse: smarthome.DataFlow.UdpResponse;
+  requestId: string;
+  deviceId: string;
+  protocol: smarthome.Constants.Protocol = smarthome.Constants.Protocol.UDP;
+  /**
+   * @param requestId  The requestId of associated `UdpRequestData`.
+   * @param deviceId  The id of the device that the request was sent to.
+   * @param udpResponse  The contents of the response.
+   * @returns  A new UdpResponseData instance
+   */
+  constructor(
+    requestId: string,
+    deviceId: string,
+    udpResponse: smarthome.DataFlow.UdpResponse
+  ) {
+    this.requestId = requestId;
+    this.deviceId = deviceId;
+    this.udpResponse = udpResponse;
+  }
+}
+
+/**
+ * An implementation of `smarthome.DataFlow.UdpResponse` for
+ * responding to UDP requests.
+ */
+export class UdpResponse implements smarthome.DataFlow.UdpResponse {
+  responsePackets?: string[];
+  /**
+   * @param responsePackets  The response packets to include in the UdpResponse, if any
+   * @returns  A new `UdpResponse` instance.
+   */
+  constructor(responsePackets?: string[]) {
+    this.responsePackets = responsePackets;
+  }
+}

--- a/src/radio/radio-controller.ts
+++ b/src/radio/radio-controller.ts
@@ -1,0 +1,166 @@
+import * as dgram from 'dgram';
+import {UdpResponse} from './dataflow';
+
+/**
+ * A default radio timeout, in milliseconds.
+ */
+const RADIO_TIMEOUT = 2500;
+
+/**
+ * A class to contain all parameters required to perform
+ * a UDP scan.
+ */
+export class UDPScanConfig {
+  broadcastAddress: string;
+  broadcastPort: number;
+  listenPort: number;
+  discoveryPacket: string;
+  /**
+   *
+   * @param broadcastAddress  The destination UDP broadcast address.
+   * @param broadcastPort  The destination UDP broadcast port.
+   * @param listenport  The listen port for the UDP response.
+   * @param discoveryPacket  The payload to send in the UDP broadcast.
+   * @returns  A new `UDPScanConfig` instance.
+   */
+  constructor(
+    broadcastAddress: string,
+    broadcastPort: number,
+    listenport: number,
+    discoveryPacket: string
+  ) {
+    this.broadcastAddress = broadcastAddress;
+    this.broadcastPort = broadcastPort;
+    this.listenPort = listenport;
+    this.discoveryPacket = discoveryPacket;
+  }
+}
+
+/**
+ * A class to contain the information from a UDP scan.
+ */
+export interface UDPScanResults {
+  buffer: Buffer;
+  address: string;
+}
+
+/**
+ * A class to contain all Node radio functionality.
+ */
+export class RadioController {
+  /**
+   * A helper function to create timeout promises.
+   * @returns  A new Promise that resolves after RADIO_TIMEOUS milliseconds.
+   */
+  private createTimeoutPromise(): Promise<void> {
+    return new Promise(resolve => {
+      setTimeout(resolve, RADIO_TIMEOUT);
+    });
+  }
+
+  /**
+   * Performs a UDP scan according to a `UDPScanConfig`.
+   * @param udpScanConfig  A scan configuration containing UDP parameters.
+   * @return  A promise that resolves to the determined `UDPScanResults`
+   */
+  public async udpScan(udpScanConfig: UDPScanConfig): Promise<UDPScanResults> {
+    // Open a UDP socket.
+    const socket = dgram.createSocket('udp4');
+    const discoveryBuffer = new Promise<UDPScanResults>(resolve => {
+      // Resolve promise when a broadcast buffer is recieved.
+      socket.on('message', (msg, rinfo) => {
+        // Close the socket.
+        socket.close();
+        resolve({buffer: msg, address: rinfo.address});
+      });
+
+      // Enable UDP broadcast.
+      socket.on('listening', () => {
+        socket.setBroadcast(true);
+      });
+      socket.bind(udpScanConfig.listenPort);
+
+      // Decode the discovery packet and send it.
+      const payload = Buffer.from(udpScanConfig.discoveryPacket, 'hex');
+      socket.send(
+        payload,
+        udpScanConfig.broadcastPort,
+        udpScanConfig.broadcastAddress,
+        error => {
+          if (error !== null) {
+            throw new Error(
+              'Failed to send UDP discovery packet:' + error.message
+            );
+          }
+          console.log('Sent UDP discovery packet: ', payload);
+        }
+      );
+    });
+    // Timeout if there hasn't been a response.
+    return Promise.race([
+      discoveryBuffer,
+      this.createTimeoutPromise().then(() => {
+        // Close the socket if timed out
+        socket.close();
+        throw new Error(
+          'UDP scan timed out after ' + RADIO_TIMEOUT.toString() + 'ms.'
+        );
+      }),
+    ]);
+  }
+
+  /**
+   * Sends a UDP message using the given parameters
+   * @param payload  The payload to send in the UDP message.
+   * @param address  The destination address of the UDP message.
+   * @param lisenPort  The port to listen on for a response, if execting one.
+   * @param expectedResponsePackets  The number of responses to save before resolving.
+   * @returns  A promise that resolves to the determined `UDPResponse`.
+   */
+  public async sendUdpMessage(
+    payload: Buffer,
+    address: string,
+    port: number,
+    listenPort: number,
+    expectedResponsePackets = 0
+  ): Promise<smarthome.DataFlow.UdpResponse> {
+    const responsePackets: string[] = [];
+    // Open a UDP socket
+    const socket = dgram.createSocket('udp4');
+    const discoveryBuffer = new Promise<smarthome.DataFlow.UdpResponse>(
+      resolve => {
+        // Record any UDP messages as responses.
+        socket.on('message', msg => {
+          responsePackets.push(msg.toString('hex'));
+          if (responsePackets.length >= expectedResponsePackets) {
+            socket.close();
+            resolve(new UdpResponse(responsePackets));
+          }
+        });
+        // Start listening for responses.
+        socket.bind(listenPort);
+        // Send the UDP message, forwarding the given parameters.
+        socket.send(payload, port, address, error => {
+          if (error !== null) {
+            throw new Error('Failed to send UDP message:' + error.message);
+          }
+          console.log('Sent UDP message: ', payload);
+          if (expectedResponsePackets === 0) {
+            // Resolve early if we aren't expecting any response.
+            resolve(new UdpResponse());
+          }
+        });
+      }
+    );
+    // Timeout if still waiting for a response.
+    return Promise.race([
+      discoveryBuffer,
+      this.createTimeoutPromise().then(() => {
+        socket.close();
+        throw new Error(
+          'UDP send timed out after ' + RADIO_TIMEOUT.toString() + 'ms.'
+        );
+      }),
+    ]);
+  }
+}

--- a/src/radio/radio-controller.ts
+++ b/src/radio/radio-controller.ts
@@ -61,6 +61,7 @@ export class RadioController {
   /**
    * Performs a UDP scan according to a `UDPScanConfig`.
    * @param udpScanConfig  A scan configuration containing UDP parameters.
+   * @param timeout  How long in ms to wait before timing out the request.
    * @return  A promise that resolves to the determined `UDPScanResults`
    */
   public async udpScan(
@@ -105,7 +106,7 @@ export class RadioController {
       this.createTimeoutPromise(timeout).then(() => {
         // Close the socket if timed out
         socket.close();
-        throw new Error(`UDP scan timed out after ${RADIO_TIMEOUT}ms.`);
+        throw new Error(`UDP scan timed out after ${timeout}ms.`);
       }),
     ]);
   }
@@ -116,6 +117,7 @@ export class RadioController {
    * @param address  The destination address of the UDP message.
    * @param listenPort  The port to listen on for a response, if execting one.
    * @param expectedResponsePackets  The number of responses to save before resolving.
+   * @param timeout  How long in ms to wait before timing out the request.
    * @returns  A promise that resolves to the determined `UDPResponse`.
    */
   public async sendUdpMessage(
@@ -159,7 +161,7 @@ export class RadioController {
       discoveryBuffer,
       this.createTimeoutPromise(timeout).then(() => {
         socket.close();
-        throw new Error(`UDP send timed out after ${RADIO_TIMEOUT} ms.`);
+        throw new Error(`UDP send timed out after ${timeout} ms.`);
       }),
     ]);
   }

--- a/src/radio/radio-device-manager.ts
+++ b/src/radio/radio-device-manager.ts
@@ -12,7 +12,7 @@ const DEFAULT_LISTEN_PORT = 3311;
 export class RadioDeviceManager implements smarthome.DeviceManager {
   private radioController: RadioController;
   private listenPort: number;
-  public deviceIdToAddress: Map<string, string> = new Map<string, string>();
+  private deviceIdToAddress: Map<string, string> = new Map<string, string>();
 
   /**
    * @param  radioController  The radio controller used for radio communication.

--- a/src/radio/radio-device-manager.ts
+++ b/src/radio/radio-device-manager.ts
@@ -1,0 +1,92 @@
+import {RadioController} from './radio-controller';
+import {UdpResponseData} from './dataflow';
+
+/**
+ * The default port to listen on for radio responses.
+ */
+const DEFAULT_LISTEN_PORT = 3311;
+
+/**
+ * An implementation of `smarthome.DeviceManager` that implements radio functionality.
+ */
+export class RadioDeviceManager implements smarthome.DeviceManager {
+  private radioController: RadioController;
+  private listenPort: number;
+  public deviceIdToAddress: Map<string, string> = new Map<string, string>();
+
+  /**
+   * @param  radioController  The radio controller used for radio communication.
+   * @param  listenPort  The port to listen on for radio responses.
+   */
+  constructor(
+    radioController: RadioController,
+    listenPort: number = DEFAULT_LISTEN_PORT
+  ) {
+    this.radioController = radioController;
+    this.listenPort = listenPort;
+  }
+
+  /**
+   * Associates a deviceId with an IP address.
+   * Required for routing Execute commands.
+   * @param deviceId The deviceId of the device
+   * @param address The address of the device
+   */
+  public addDeviceIdToAddress(deviceId: string, address: string): void {
+    this.deviceIdToAddress.set(deviceId, address);
+  }
+
+  markPending(request: smarthome.IntentRequest): Promise<void> {
+    //TODO(cjdaly) implementation
+    return Promise.resolve();
+  }
+
+  getProxyInfo(id: string): smarthome.ProxyInfo {
+    //TODO(cjdaly) implementation
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Fulfills a UdpRquestData.
+   * @param udpRequestData  The UdpRequestData to source radio parameters from.
+   * @returns  A promise that resolves to the determined UdpResponseData.
+   */
+  private async processUdpRequestData(
+    udpRequestData: smarthome.DataFlow.UdpRequestData
+  ): Promise<smarthome.DataFlow.UdpResponseData> {
+    const payload = Buffer.from(udpRequestData.data, 'hex');
+    const localAddress = this.deviceIdToAddress.get(udpRequestData.deviceId);
+    const udpResponse = await this.radioController.sendUdpMessage(
+      payload,
+      localAddress!,
+      udpRequestData.port,
+      this.listenPort,
+      udpRequestData.expectedResponsePackets
+    );
+    return new UdpResponseData(
+      udpRequestData.requestId,
+      udpRequestData.deviceId,
+      udpResponse
+    );
+  }
+
+  /**
+   * Sends a true radio command based on the contents of a `CommandRequest`
+   * @param command  The `CommandRequest` to process.
+   * @returns  The determined `CommandBase` response.
+   */
+  public async send(
+    command: smarthome.DataFlow.CommandRequest
+  ): Promise<smarthome.DataFlow.CommandBase> {
+    if (!this.deviceIdToAddress.has(command.deviceId)) {
+      throw new smarthome.IntentFlow.HandlerError(command.requestId);
+    }
+    console.log(command);
+    if (command.protocol === 'UDP') {
+      return await this.processUdpRequestData(
+        command as smarthome.DataFlow.UdpRequestData
+      );
+    }
+    throw new Error('Radio protocol not recognized');
+  }
+}

--- a/test/cli/worker-instance-test.ts
+++ b/test/cli/worker-instance-test.ts
@@ -1,0 +1,20 @@
+import test from 'ava';
+import {Worker} from 'worker_threads';
+
+const APP_INSTANCE_PATH = './build/src/cli/app-instance.js';
+const INVALID_FILE_PATH = '/this/is/a/file/path/that/doesnt/exist/index.js';
+
+test('invalid-file-path-bubbles-error', async t => {
+  const error: Error = await new Promise<Error>(resolve => {
+    new Worker(APP_INSTANCE_PATH, {
+      workerData: INVALID_FILE_PATH,
+    }).on('error', error => {
+      resolve(error);
+    });
+  });
+
+  t.is(
+    error.message,
+    'File at path /this/is/a/file/path/that/doesnt/exist/index.js not found.'
+  );
+});

--- a/test/example/fixtures.ts
+++ b/test/example/fixtures.ts
@@ -37,7 +37,6 @@ export function identifyHandler(
  * @param deviceManager  The `DeviceManager` to forward the `CommandRequest` to.
  * @returns  An Execute handler that sends the given command to the
  *     given `DeviceManager`.
- *
  */
 export function createExecuteHandler(
   deviceCommand: smarthome.DataFlow.CommandRequest,

--- a/test/platform/test-device-manager.ts
+++ b/test/platform/test-device-manager.ts
@@ -3,7 +3,7 @@
  */
 import test from 'ava';
 import {
-  DeviceManagerStub,
+  MockDeviceManager,
   ERROR_UNEXPECTED_COMMAND_REQUEST,
   ERROR_PENDING_REQUEST_MISMATCH,
   UdpResponseData,
@@ -62,7 +62,7 @@ function createExecuteRequest(
  * Tests that `markPending()` matches two identical requests.
  */
 test('device-manager-expected-mark-pending', async t => {
-  const deviceManager = new DeviceManagerStub();
+  const deviceManager = new MockDeviceManager();
   const executeRequest = createExecuteRequest('action.devices.commands.OnOff', {
     on: true,
   });
@@ -77,7 +77,7 @@ test('device-manager-expected-mark-pending', async t => {
  * Tests that `markPending()` differentiates two different requests.
  */
 test('device-manager-unexpected-mark-pending', async t => {
-  const deviceManager = new DeviceManagerStub();
+  const deviceManager = new MockDeviceManager();
   const executeRequest = createExecuteRequest('action.devices.commands.OnOff', {
     on: true,
   });
@@ -104,7 +104,7 @@ test('device-manager-unexpected-mark-pending', async t => {
  * Tests that an unexpected Execute request throws a `HandlerError`.
  */
 test('test-unexpected-command-request', async t => {
-  const deviceManager = new DeviceManagerStub();
+  const deviceManager = new MockDeviceManager();
   await t.throwsAsync(
     async () => {
       await deviceManager.send(COMMAND_REQUEST);
@@ -121,7 +121,7 @@ test('test-unexpected-command-request', async t => {
  * and resets them properly.
  */
 test('test-sent-requests', async t => {
-  const deviceManager = new DeviceManagerStub();
+  const deviceManager = new MockDeviceManager();
   const commandResponse = new UdpResponseData(
     EXECUTE_REQUEST_ID,
     DEVICE_ID,

--- a/test/radio/radio-controller-test.ts
+++ b/test/radio/radio-controller-test.ts
@@ -1,0 +1,76 @@
+import test from 'ava';
+import * as dgram from 'dgram';
+import {RadioController, UDPScanConfig} from '../../src/radio/radio-controller';
+import {UdpResponse} from '../../src';
+
+const UDP_DUMMY_BUFFER_1 = Buffer.from('test UDP buffer');
+const UDP_DUMMY_BUFFER_2 = Buffer.from('foo bar lorem ipsum');
+
+/**
+ * Class to manage a local UDP server
+ */
+class UdpServer {
+  private server: dgram.Socket | undefined;
+  public startServer(listenPort = 3112) {
+    this.server = dgram.createSocket('udp4');
+    this.server.on('message', (message: Buffer, rinfo) => {
+      this.server!.send(UDP_DUMMY_BUFFER_1, rinfo.port, rinfo.address);
+      this.server!.send(UDP_DUMMY_BUFFER_2, rinfo.port, rinfo.address);
+    });
+    this.server.bind(listenPort);
+  }
+  public stopServer() {
+    this.server?.close();
+  }
+}
+
+/**
+ * Tests that a UDP scan finds a simple UDP server
+ * and properly returns the UDP discovery data.
+ */
+test.serial('udp-scan-finds-server', async t => {
+  const serverPort = 3112;
+  const listenPort = 3111;
+  const scanConfig = new UDPScanConfig(
+    'localhost',
+    serverPort,
+    listenPort,
+    UDP_DUMMY_BUFFER_2.toString('hex')
+  );
+  const udpServer = new UdpServer();
+  udpServer.startServer(serverPort);
+
+  const expectedScanResults = {
+    buffer: UDP_DUMMY_BUFFER_1,
+    address: '127.0.0.1',
+  };
+  const radioController = new RadioController();
+  const scanResults = await radioController.udpScan(scanConfig);
+  udpServer.stopServer();
+  t.deepEqual(expectedScanResults, scanResults);
+});
+
+/**
+ * Tests that a `sendUDPMessage` returns with the correct
+ * response packets
+ */
+test.serial('udp-message-recieves-all-data', async t => {
+  const serverPort = 3112;
+  const listenPort = 3001;
+  const udpServer = new UdpServer();
+  udpServer.startServer(serverPort);
+  const radioController = new RadioController();
+  const expectedUdpResponse = new UdpResponse([
+    UDP_DUMMY_BUFFER_1.toString('hex'),
+    UDP_DUMMY_BUFFER_2.toString('hex'),
+  ]);
+  const udpResponse = await radioController.sendUdpMessage(
+    Buffer.from('nothing important'),
+    'localhost',
+    serverPort,
+    listenPort,
+    2
+  );
+  udpServer.stopServer();
+  t.deepEqual(expectedUdpResponse, udpResponse);
+});

--- a/test/radio/radio-controller-test.ts
+++ b/test/radio/radio-controller-test.ts
@@ -42,7 +42,12 @@ test.serial('udp-scan-finds-server', async t => {
 
   const expectedScanResults = {
     buffer: UDP_DUMMY_BUFFER_1,
-    address: '127.0.0.1',
+    rinfo: {
+      address: '127.0.0.1',
+      family: 'IPv4',
+      port: serverPort,
+      size: 15,
+    },
   };
   const radioController = new RadioController();
   const scanResults = await radioController.udpScan(scanConfig);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This PR adds true UDP radio functionality from Node for Identify and Execute requests as well as a CLI interface.

**Changes:**
- Added `CommandProcessor` class, which handles command line arguments and maintains a parent-worker loop to process commands until an exit is received.
- Added `udp-scan` command path, which broadcasts on `UDP` and forwards a response to the Identify handler fulfillment path.
- Added `simulate-identify` command path, which triggers the fulfillment's Identify handler with given parameters
- Added `trigger-execute` command path, which triggers an `ExecuteRequest`
- Added `PlatformWorker` class, which runs on a worker thread orchestrates CLI command processing across all stubs.
- Added stubs for `smarthome.DataFlow`
- Added `RadioController` class, which node handles radio communication protocols.
- Added `RadioDeviceManager`, which implements `smarthome.DeviceManager` with true radio fulfillment.
- Rename `DeviceManagerStub` to `MockDeviceManager`

**Notes:**
- I've manually tested functionality with the [ Local Home SDK Virtual Device](https://github.com/actions-on-google/smart-home-local/tree/master/device).  Some commands I used can be found in `/src/cli/README.md`

**Related Issues:**
- Progresses #2
- Resolves #46  
- Resolves #37  