### PR TITLE
Add TCP radio functionality to command line interface

### DIFF
--- a/src/platform/stub-setup.ts
+++ b/src/platform/stub-setup.ts
@@ -19,6 +19,9 @@ export const smarthomeStub: {
   };
   Constants: {
     Protocol: {[key in keyof typeof smarthome.Constants.Protocol]: string};
+    TcpOperation: {
+      [key in keyof typeof smarthome.Constants.TcpOperation]: string;
+    };
   };
 } = {
   App: AppStub,
@@ -49,6 +52,10 @@ export const smarthomeStub: {
       TCP: 'TCP',
       UDP: 'UDP',
       BLE_MESH: 'BLE_MESH',
+    },
+    TcpOperation: {
+      READ: 'READ',
+      WRITE: 'WRITE',
     },
   },
 };

--- a/src/radio/dataflow.ts
+++ b/src/radio/dataflow.ts
@@ -9,6 +9,17 @@ export const DataFlowStub = {
     data = '';
     port = 0;
   },
+  TcpRequestData: class {
+    protocol: smarthome.Constants.Protocol = smarthome.Constants.Protocol.TCP;
+    requestId = '';
+    deviceId = '';
+    data = '';
+    bytesToRead?: number;
+    hostname?: string;
+    port = 0;
+    operation: smarthome.Constants.TcpOperation =
+      smarthome.Constants.TcpOperation.WRITE;
+  },
 };
 
 /**
@@ -49,5 +60,42 @@ export class UdpResponse implements smarthome.DataFlow.UdpResponse {
    */
   constructor(responsePackets?: string[]) {
     this.responsePackets = responsePackets;
+  }
+}
+
+/**
+ * An implementation of `smarthome.DataFlow.TcpResponseData` for
+ * responding to TCP requests.
+ */
+export class TcpResponseData implements smarthome.DataFlow.TcpResponseData {
+  tcpResponse: smarthome.DataFlow.TcpResponse;
+  requestId: string;
+  deviceId: string;
+  protocol: smarthome.Constants.Protocol = smarthome.Constants.Protocol.UDP;
+  /**
+   * @param requestId  The requestId of the corresponding `TcpRequestData`.
+   * @param deviceId  The id of the device that the request was sent to.
+   * @param tcpResponse  The contents of the response.
+   * @returns  A new `TcpResponseData` instance
+   */
+  constructor(
+    requestId: string,
+    deviceId: string,
+    tcpResponse: smarthome.DataFlow.TcpResponse
+  ) {
+    this.requestId = requestId;
+    this.deviceId = deviceId;
+    this.tcpResponse = tcpResponse;
+  }
+}
+
+/**
+ * An implementation of `smarthome.DataFlow.TcpResponse` for
+ * responding to TCP requests.
+ */
+export class TcpResponse implements smarthome.DataFlow.TcpResponse {
+  data: string;
+  constructor(data = '') {
+    this.data = data;
   }
 }

--- a/test/cli/worker-instance-test.ts
+++ b/test/cli/worker-instance-test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import {Worker} from 'worker_threads';
 
-const APP_INSTANCE_PATH = './build/src/cli/app-instance.js';
+const APP_INSTANCE_PATH = './build/src/cli/worker-instance.js';
 const INVALID_FILE_PATH = '/this/is/a/file/path/that/doesnt/exist/index.js';
 
 test('invalid-file-path-bubbles-error', async t => {

--- a/test/radio/radio-controller-test.ts
+++ b/test/radio/radio-controller-test.ts
@@ -1,10 +1,13 @@
+import * as net from 'net';
 import test from 'ava';
 import * as dgram from 'dgram';
 import {RadioController, UDPScanConfig} from '../../src/radio/radio-controller';
-import {UdpResponse} from '../../src';
+import {UdpResponse, TcpResponse} from '../../src';
 
-const UDP_DUMMY_BUFFER_1 = Buffer.from('test UDP buffer');
-const UDP_DUMMY_BUFFER_2 = Buffer.from('foo bar lorem ipsum');
+const UDP_PLACEHOLDER_BUFFER_1 = Buffer.from('test UDP buffer');
+const UDP_PLACEHOLDER_BUFFER_2 = Buffer.from('foo bar lorem ipsum');
+
+const TCP_PLACEHOLDER_BUFFER = Buffer.from('placeholder data');
 
 /**
  * Class to manage a local UDP server
@@ -14,8 +17,8 @@ class UdpServer {
   public startServer(listenPort = 3112) {
     this.server = dgram.createSocket('udp4');
     this.server.on('message', (message: Buffer, rinfo) => {
-      this.server!.send(UDP_DUMMY_BUFFER_1, rinfo.port, rinfo.address);
-      this.server!.send(UDP_DUMMY_BUFFER_2, rinfo.port, rinfo.address);
+      this.server!.send(UDP_PLACEHOLDER_BUFFER_1, rinfo.port, rinfo.address);
+      this.server!.send(UDP_PLACEHOLDER_BUFFER_2, rinfo.port, rinfo.address);
     });
     this.server.bind(listenPort);
   }
@@ -25,6 +28,49 @@ class UdpServer {
 }
 
 /**
+ * Class to manage a simple TCP server for testing.
+ */
+class TcpServer {
+  private server: net.Server | undefined;
+  private onDataRecieved: ((data: Buffer) => void) | undefined;
+
+  /**
+   * Starts a simple TCP server that writes and recieves data from a socket.
+   * @param listenPort  The port to listen on.
+   */
+  public startServer(listenPort = 3312): void {
+    this.server = net.createServer(socket => {
+      socket.write(TCP_PLACEHOLDER_BUFFER);
+      socket.on('data', data => {
+        if (this.onDataRecieved !== undefined) {
+          this.onDataRecieved(data);
+        }
+      });
+    });
+    this.server.listen(listenPort);
+  }
+
+  /**
+   * Returns the next buffer written to the server.
+   * @returns  A promise that resolves to the next data buffer recieved.
+   */
+  public async getWrittenData(): Promise<Buffer> {
+    return new Promise(resolve => {
+      this.onDataRecieved = (data: Buffer) => {
+        resolve(data);
+      };
+    });
+  }
+
+  /**
+   * Closes the TCP server, if possible.
+   */
+  public closeServer(): void {
+    this.server?.close();
+  }
+}
+
+/*
  * Tests that a UDP scan finds a simple UDP server
  * and properly returns the UDP discovery data.
  */
@@ -35,13 +81,13 @@ test.serial('udp-scan-finds-server', async t => {
     'localhost',
     serverPort,
     listenPort,
-    UDP_DUMMY_BUFFER_2.toString('hex')
+    UDP_PLACEHOLDER_BUFFER_2.toString('hex')
   );
   const udpServer = new UdpServer();
   udpServer.startServer(serverPort);
 
   const expectedScanResults = {
-    buffer: UDP_DUMMY_BUFFER_1,
+    buffer: UDP_PLACEHOLDER_BUFFER_1,
     rinfo: {
       address: '127.0.0.1',
       family: 'IPv4',
@@ -66,8 +112,8 @@ test.serial('udp-message-recieves-all-data', async t => {
   udpServer.startServer(serverPort);
   const radioController = new RadioController();
   const expectedUdpResponse = new UdpResponse([
-    UDP_DUMMY_BUFFER_1.toString('hex'),
-    UDP_DUMMY_BUFFER_2.toString('hex'),
+    UDP_PLACEHOLDER_BUFFER_1.toString('hex'),
+    UDP_PLACEHOLDER_BUFFER_2.toString('hex'),
   ]);
   const udpResponse = await radioController.sendUdpMessage(
     Buffer.from('nothing important'),
@@ -78,4 +124,41 @@ test.serial('udp-message-recieves-all-data', async t => {
   );
   udpServer.stopServer();
   t.deepEqual(expectedUdpResponse, udpResponse);
+});
+/**
+ * Tests that `readTcpSocket()` is able to read data from a TCP server.
+ */
+test.serial('tcp-read-operation-reads-from-server', async t => {
+  const serverPort = 3312;
+  const tcpServer = new TcpServer();
+  tcpServer.startServer(serverPort);
+  const radioController = new RadioController();
+  const expectedTcpResponse = new TcpResponse(
+    TCP_PLACEHOLDER_BUFFER.toString('hex')
+  );
+  const actualTcpResponse = await radioController.readTcpSocket(
+    'localhost',
+    serverPort
+  );
+  tcpServer.closeServer();
+  t.deepEqual(actualTcpResponse, expectedTcpResponse);
+});
+
+/**
+ * Tests that `writeTcpSocket()` is able to write data to a TCP server.
+ */
+test.serial('tcp-write-operation-writes-data', async t => {
+  const serverPort = 3312;
+  const tcpServer = new TcpServer();
+  tcpServer.startServer(serverPort);
+  const radioController = new RadioController();
+  const expectedTcpResponse = new TcpResponse();
+  const actualTcpResponse = await radioController.writeTcpSocket(
+    TCP_PLACEHOLDER_BUFFER,
+    'localhost',
+    serverPort
+  );
+  tcpServer.closeServer();
+  t.deepEqual(actualTcpResponse, expectedTcpResponse);
+  t.deepEqual(await tcpServer.getWrittenData(), TCP_PLACEHOLDER_BUFFER);
 });


### PR DESCRIPTION
This PR adds TCP functionality to the command line interface.  It adds stubs and implementations of TCP request and response classes.

**Changes**
- Add `smarthome.Constants.TcpOperation` stub
- Add `smarthome.Dataflow.TcpRequestData` stub
- Add implementation of `smarthome.DataFlow.TcpResponseData` and `smarthome.DataFlow.TcpResponse`
- Add `readTcpSocket()` and `writeTcpSocket` to `RadioController`
- Add `processTcpRequestData()` to `RadioDeviceManager`
- Renamed a couple UDP test variables.
- Fixed an unrelated test where an incorrect file path was being referenced (`worker-instance-test`)

**Notes:**
- See automatic tests for TCP reads/writes. I've also manually tested writing to the Local Home Sample device.
~~- Once tests are added, #48 is merged, and this PR is rebased, I'll open for review.~~
~~- Still would appreciate feedback in the meantime.~~

**Issues:**
- Resolves #50 
- Resolves #2