### PR TITLE
Add HTTP radio functionality to command line interface

### DIFF
--- a/src/platform/stub-setup.ts
+++ b/src/platform/stub-setup.ts
@@ -11,9 +11,7 @@ export const smarthomeStub: {
   App: typeof smarthome.App;
   Execute: typeof smarthome.Execute;
   Intents: {[key in keyof typeof smarthome.Intents]: string};
-  DataFlow: {
-    UdpRequestData: typeof smarthome.DataFlow.UdpRequestData;
-  };
+  DataFlow: typeof smarthome.DataFlow;
   IntentFlow: {
     HandlerError: typeof smarthome.IntentFlow.HandlerError;
   };
@@ -21,6 +19,9 @@ export const smarthomeStub: {
     Protocol: {[key in keyof typeof smarthome.Constants.Protocol]: string};
     TcpOperation: {
       [key in keyof typeof smarthome.Constants.TcpOperation]: string;
+    };
+    HttpOperation: {
+      [key in keyof typeof smarthome.Constants.HttpOperation]: string;
     };
   };
 } = {
@@ -56,6 +57,11 @@ export const smarthomeStub: {
     TcpOperation: {
       READ: 'READ',
       WRITE: 'WRITE',
+    },
+    HttpOperation: {
+      GET: 'GET',
+      POST: 'POST',
+      PUT: 'PUT',
     },
   },
 };

--- a/src/radio/dataflow.ts
+++ b/src/radio/dataflow.ts
@@ -20,6 +20,19 @@ export const DataFlowStub = {
     operation: smarthome.Constants.TcpOperation =
       smarthome.Constants.TcpOperation.WRITE;
   },
+  HttpRequestData: class {
+    protocol: smarthome.Constants.Protocol = smarthome.Constants.Protocol.HTTP;
+    requestId = '';
+    deviceId = '';
+    data = '';
+    dataType = '';
+    headers = '';
+    additionalHeaders: {[key: string]: string} = {};
+    method: smarthome.Constants.HttpOperation =
+      smarthome.Constants.HttpOperation.GET;
+    path = '';
+    port?: number;
+  },
 };
 
 /**
@@ -45,21 +58,6 @@ export class UdpResponseData implements smarthome.DataFlow.UdpResponseData {
     this.requestId = requestId;
     this.deviceId = deviceId;
     this.udpResponse = udpResponse;
-  }
-}
-
-/**
- * An implementation of `smarthome.DataFlow.UdpResponse` for
- * responding to UDP requests.
- */
-export class UdpResponse implements smarthome.DataFlow.UdpResponse {
-  responsePackets?: string[];
-  /**
-   * @param responsePackets  The response packets to include in the UdpResponse, if any
-   * @returns  A new `UdpResponse` instance.
-   */
-  constructor(responsePackets?: string[]) {
-    this.responsePackets = responsePackets;
   }
 }
 
@@ -90,6 +88,47 @@ export class TcpResponseData implements smarthome.DataFlow.TcpResponseData {
 }
 
 /**
+ * An implementation of `smarthome.DataFlow.HttpResponseData` for
+ * responding to HTTP requests.
+ */
+export class HttpResponseData implements smarthome.DataFlow.HttpResponseData {
+  deviceId: string;
+  httpResponse: smarthome.DataFlow.HttpResponse;
+  protocol: smarthome.Constants.Protocol = smarthome.Constants.Protocol.HTTP;
+  requestId: string;
+  /**
+   * @param deviceId  The id of the device that the request was sent to.
+   * @param httpResponse  The contents of the response.
+   * @param requestId  The requestId of the associated `HttpRequestData`
+   * @returns  A new `HttpResponseData` instance.
+   */
+  constructor(
+    deviceId: string,
+    httpResponse: smarthome.DataFlow.HttpResponse,
+    requestId: string
+  ) {
+    this.deviceId = deviceId;
+    this.httpResponse = httpResponse;
+    this.requestId = requestId;
+  }
+}
+
+/**
+ * An implementation of `smarthome.DataFlow.UdpResponse` for
+ * responding to UDP requests.
+ */
+export class UdpResponse implements smarthome.DataFlow.UdpResponse {
+  responsePackets?: string[];
+  /**
+   * @param responsePackets  The response packets to include in the UdpResponse, if any
+   * @returns  A new `UdpResponse` instance.
+   */
+  constructor(responsePackets?: string[]) {
+    this.responsePackets = responsePackets;
+  }
+}
+
+/**
  * An implementation of `smarthome.DataFlow.TcpResponse` for
  * responding to TCP requests.
  */
@@ -97,5 +136,23 @@ export class TcpResponse implements smarthome.DataFlow.TcpResponse {
   data: string;
   constructor(data = '') {
     this.data = data;
+  }
+}
+
+/**
+ * An implementation of `smarthome.DataFlow.UdpResponse` for
+ * responding to HTTP requests.
+ */
+export class HttpResponse implements smarthome.DataFlow.HttpResponse {
+  body: unknown;
+  statusCode: number;
+  /**
+   * @param body  The body of the HTTP response.
+   * @param statusCode  The HTTP response code.
+   * @returns  A new `HttpResponse` instance.
+   */
+  constructor(body: unknown, statusCode: number) {
+    this.body = body;
+    this.statusCode = statusCode;
   }
 }

--- a/src/radio/radio-controller.ts
+++ b/src/radio/radio-controller.ts
@@ -1,6 +1,7 @@
+import {TcpResponse, UdpResponse, HttpResponse} from './dataflow';
 import * as dgram from 'dgram';
+import * as http from 'http';
 import * as net from 'net';
-import {UdpResponse, TcpResponse} from './dataflow';
 
 /**
  * A default radio timeout, in milliseconds.
@@ -203,6 +204,51 @@ export class RadioController {
   }
 
   /**
+   * Sends an HTTP GET request using the provided parameters.
+   * @param host  The address to send the HTTP GET request to.
+   * @param port  The port to send the HTTP GET request to.
+   * @param path  The path to send the HTTP GET request to.
+   * @param timeout  How long to wait before rejecting with a timeout.
+   */
+  public async sendHttpGet(
+    host: string,
+    port: number,
+    path: string,
+    timeout = RADIO_TIMEOUT
+  ): Promise<smarthome.DataFlow.HttpResponse> {
+    const options = {
+      host,
+      port,
+      path,
+    };
+    const httpResponse = new Promise<smarthome.DataFlow.HttpResponse>(
+      resolve => {
+        http.get(options, res => {
+          const {statusCode} = res;
+          const dataBuffer: string[] = [];
+          if (statusCode !== 200) {
+            throw new Error(`Request Failed.\nStatus Code: ${statusCode}`);
+          }
+          res.setEncoding('utf8');
+          res.on('data', chunk => {
+            dataBuffer.push(chunk);
+          });
+          res.on('end', () => {
+            resolve(new HttpResponse(dataBuffer.join(''), statusCode));
+          });
+        });
+      }
+    );
+    // Timeout if still waiting for a response.
+    return Promise.race([
+      httpResponse,
+      this.createTimeoutPromise(timeout).then(() => {
+        throw new Error(`HTTP GET request timed out after ${timeout}ms.`);
+      }),
+    ]);
+  }
+
+  /**
    * Open a TCP socket and write to it.
    * @param payload  The payload to send in the TCP write.
    * @param address  The address to write to.
@@ -231,6 +277,60 @@ export class RadioController {
       discoveryBuffer,
       this.createTimeoutPromise(timeout).then(() => {
         throw new Error(`TCP write timed out after ${timeout}ms.`);
+      }),
+    ]);
+  }
+
+  /**
+   * Sends an HTTP POST request using the provided parameters.
+   * @param host  The address to send the HTTP POST request to.
+   * @param port  The port to send the HTTP POST request to.
+   * @param path  The path to send the HTTP POST request to.
+   * @param timeout  How long to wait before rejecting with a timeout.
+   */
+  public async sendHttpPost(
+    host: string,
+    port: number,
+    path: string,
+    dataType: string,
+    data: string,
+    timeout = RADIO_TIMEOUT
+  ): Promise<smarthome.DataFlow.HttpResponse> {
+    const options = {
+      host,
+      port,
+      path,
+      method: 'POST',
+      headers: {
+        'Content-Type': dataType,
+        'Content-Length': Buffer.byteLength(data),
+      },
+    };
+    const httpResponse = new Promise<smarthome.DataFlow.HttpResponse>(
+      resolve => {
+        const postRequest = http.request(options, res => {
+          const {statusCode} = res;
+          const dataBuffer: string[] = [];
+          if (statusCode !== 200) {
+            throw new Error(`Request Failed.\nStatus Code: ${statusCode}`);
+          }
+          res.setEncoding('utf8');
+          res.on('data', chunk => {
+            dataBuffer.push(chunk);
+          });
+          res.on('end', () => {
+            resolve(new HttpResponse(dataBuffer.join(''), statusCode));
+          });
+        });
+        postRequest.write(data);
+        postRequest.end();
+      }
+    );
+    // Timeout if still waiting for a response.
+    return Promise.race([
+      httpResponse,
+      this.createTimeoutPromise(timeout).then(() => {
+        throw new Error(`HTTP POST request timed out after ${timeout}ms.`);
       }),
     ]);
   }


### PR DESCRIPTION
This PR adds HTTP functionality to the command line interface.  It adds stubs and implementations of HTTP request and response classes.

**Changes**
- Add `smarthome.Constants.HttpOperation` stub
- Add `smarthome.Dataflow.HttpRequestData` stub
- Add implementation of `smarthome.DataFlow.HttpResponseData` and `smarthome.DataFlow.HttpResponse`
- Add `sendHttpGet()` and `sendHttpPost()` to `RadioController`
- Add `processHttpRequestData()` to `RadioDeviceManager`

**Notes:**
~~- Once #48 is merged, and this PR is rebased, I'll open for review.~~
~~- Still would appreciate feedback in the meantime.~~

**Issues:**
- Resolves #51 
- Resolves #2