### PR TITLE
Add missing request_id option from execute command

### DIFF
--- a/src/cli/command-processor.ts
+++ b/src/cli/command-processor.ts
@@ -87,6 +87,11 @@ export class CommandProcessor {
       )
       .command('trigger-execute', 'Trigger an Execute command.', yargs => {
         return yargs
+          .option('request_id', {
+            describe: 'The request Id',
+            type: 'string',
+            demandOption: true,
+          })
           .option('local_device_id', {
             describe: 'The local device Id',
             type: 'string',


### PR DESCRIPTION
The `yargs` `trigger-execute` command was missing a `request_id` option.  The switch statement that parses it into an `ExecuteMessage` was accessing this field and was passing in an `undefined`.

This PR adds that option.