### PR TITLE
Move `RadioController` UDP socket `send()` call after `bind()`

### DIFF
--- a/src/radio/radio-controller.ts
+++ b/src/radio/radio-controller.ts
@@ -142,17 +142,18 @@ export class RadioController {
           }
         });
         // Start listening for responses.
-        socket.bind(listenPort);
-        // Send the UDP message, forwarding the given parameters.
-        socket.send(payload, port, address, error => {
-          if (error) {
-            throw new Error(`Failed to send UDP message: ${error.message}`);
-          }
-          console.log('Sent UDP message: ', payload);
-          if (expectedResponsePackets === 0) {
-            // Resolve early if we aren't expecting any response.
-            resolve(new UdpResponse());
-          }
+        socket.bind(listenPort, () => {
+          // Send the UDP message, forwarding the given parameters.
+          socket.send(payload, port, address, error => {
+            if (error) {
+              throw new Error(`Failed to send UDP message: ${error.message}`);
+            }
+            console.log('Sent UDP message: ', payload);
+            if (expectedResponsePackets === 0) {
+              // Resolve early if we aren't expecting any response.
+              resolve(new UdpResponse());
+            }
+          });
         });
       }
     );


### PR DESCRIPTION
Minor bug fix that affects `RadioController`:

Previously the `sendUdpMessage()` function called `bind()`, then `send()` immediately after.  This could result in the `send()` call being called before the UDP socket is bound.  According to the [API documentation](https://nodejs.org/api/dgram.html), the `send()` call would still go through in that case, but would resort to default behavior:

>If the socket has not been previously bound with a call to bind, the socket is assigned a random port number and is bound to the "all interfaces" address ('0.0.0.0' for udp4 sockets, '::0' for udp6 sockets.)

This is not desired, so this fix moves the `send()` call into a callback that is passed as an argument for `bind()` and called when the socket is definitely bound.