### PR TITLE
Change UDPScanResults type in all references

### DIFF
--- a/stubs/src/radio/dataflow.ts
+++ b/stubs/src/radio/dataflow.ts
@@ -196,6 +196,6 @@ export interface RemoteInfo {
  * A class to contain the information from a UDP scan.
  */
 export interface UDPScanResults {
-  buffer: Buffer;
+  scanData: string;
   rinfo: RemoteInfo;
 }

--- a/stubs/src/radio/node-radio-controller.ts
+++ b/stubs/src/radio/node-radio-controller.ts
@@ -45,7 +45,7 @@ export class NodeRadioController implements RadioController {
       socket.on('message', (buffer, rinfo) => {
         // Close the socket.
         socket.close();
-        resolve({buffer, rinfo});
+        resolve({scanData: buffer.toString('hex'), rinfo});
       });
 
       // Enable UDP broadcast.

--- a/stubs/test/radio/radio-controller-test.ts
+++ b/stubs/test/radio/radio-controller-test.ts
@@ -165,7 +165,7 @@ test.serial('udp-scan-finds-server', async t => {
   udpServer.startServer(serverPort);
 
   const expectedScanResults = {
-    buffer: UDP_PLACEHOLDER_BUFFER_1,
+    scanData: UDP_PLACEHOLDER_BUFFER_1.toString('hex'),
     rinfo: {
       address: '127.0.0.1',
       family: 'IPv4',


### PR DESCRIPTION
#59 was merged with an incomplete implementation (due to a git mistake when rebasing).  This completes the implementation.

Changes `UDPScanResults` `buffer:Buffer` to `scanData:string` See #59 for full description.